### PR TITLE
Reset node neighborhood query limits.

### DIFF
--- a/client/cliqueMongoAdapter.js
+++ b/client/cliqueMongoAdapter.js
@@ -167,6 +167,15 @@
       pendingRequests.requests = {};
     };
 
+    /* Clear any query limits that have been set on nodes */
+    this.clearNodeLimits = function () {
+      _.each(this.accessors, function (node, key) {
+        if ('limit' in node) {
+          delete node['limit'];
+        }
+      });
+    };
+
     return this;
   };
 }(window.clique, window.jQuery, window._, window.Backbone, window.moment));

--- a/client/entity-align.js
+++ b/client/entity-align.js
@@ -463,6 +463,8 @@ function initGraph1WithClique () {
                                 '#info1');
   entityAlign.graph1 = graph;
 
+  graph.graph.adapter.clearNodeLimits();
+
   graph.graph.adapter.findNode({name: centralHandle}).then(function (center) {
     console.log('center:', center);
     if (center) {


### PR DESCRIPTION
Each time a node is expanded, we query additional neighbors.  This allows handling large neighbors by limiting the amount that is shown by default.  However, each time a node was queries, the limit would be increased if the node had been visible in the previous graph.  By reseting it, selecting an entity will always result in the same 1-hop network prior to expanding nodes.
